### PR TITLE
fix: presigned bean 자격증명 빌더 수정

### DIFF
--- a/src/main/java/ongi/ongibe/global/config/S3Config.java
+++ b/src/main/java/ongi/ongibe/global/config/S3Config.java
@@ -25,13 +25,18 @@ public class S3Config {
     public S3Presigner presigner() {
         return S3Presigner.builder()
                 .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
                 .build();
     }
 
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .region(Region.AP_NORTHEAST_2)
+                .region(Region.of(region))
                 .credentialsProvider(
                         StaticCredentialsProvider.create(
                                 AwsBasicCredentials.create(accessKey, secretKey)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #52 

## 📝작업 내용

> 자격증명 IAM -> access key, secret key 변경에 따른 presigned url bean 내 자격증명 builder 수정

<img width="878" alt="스크린샷 2025-05-08 13 30 01" src="https://github.com/user-attachments/assets/98472a4b-9557-42d4-acda-ab10d94537ba" />
