### PR TITLE
fix: longitude, latitude Double Wrapper class 적용

### DIFF
--- a/src/main/java/ongi/ongibe/domain/album/dto/AlbumDetailResponseDTO.java
+++ b/src/main/java/ongi/ongibe/domain/album/dto/AlbumDetailResponseDTO.java
@@ -11,8 +11,8 @@ public record AlbumDetailResponseDTO(
     public record PictureInfo(
             @Schema(description = "사진 ID") Long pictureId,
             @Schema(description = "사진 URL") String pictureURL,
-            @Schema(description = "위도") double latitude,
-            @Schema(description = "경도") double longitude,
+            @Schema(description = "위도") Double latitude,
+            @Schema(description = "경도") Double longitude,
             @Schema(description = "태그") String tag,
             @Schema(description = "품질 점수") float qualityScore,
             @Schema(description = "중복 여부") boolean isDuplicated,

--- a/src/main/java/ongi/ongibe/domain/album/dto/AlbumSummaryResponseDTO.java
+++ b/src/main/java/ongi/ongibe/domain/album/dto/AlbumSummaryResponseDTO.java
@@ -9,6 +9,6 @@ import lombok.NoArgsConstructor;
 public record AlbumSummaryResponseDTO(
         @Schema(description = "사진 id") Long pictureId,
         @Schema(description = "사진 url") String pictureURL,
-        @Schema(description = "사진 위도") double latitude,
-        @Schema(description = "사진 경도") double longitude
+        @Schema(description = "사진 위도") Double latitude,
+        @Schema(description = "사진 경도") Double longitude
 ) {}

--- a/src/main/java/ongi/ongibe/domain/user/dto/UserTotalStateResponseDTO.java
+++ b/src/main/java/ongi/ongibe/domain/user/dto/UserTotalStateResponseDTO.java
@@ -9,7 +9,7 @@ public record UserTotalStateResponseDTO(
         @Schema(description = "총 방문 장소 수") int placeCount
 ) {
     public record PictureCoordinate(
-            @Schema(description = "위도") double latitude,
-            @Schema(description = "경도") double longitude
+            @Schema(description = "위도") Double latitude,
+            @Schema(description = "경도") Double longitude
     ) {}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #197 핫픽스

## 📝작업 내용

> longitude, latitude DTO 전달 시 NPE 발생 확인
- 원인 : Picture 엔티티는 Double로 감쌌지만 DTO에서 double로 형변환 미반영 확인