### PR TITLE
fix: /api/auth api는 필터 통과하게 로직 구현

### DIFF
--- a/src/main/java/ongi/ongibe/global/security/config/SecurityConfig.java
+++ b/src/main/java/ongi/ongibe/global/security/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:5173", "http://ongi.today"));
+        configuration.setAllowedOrigins(List.of("http://localhost:5173", "https://ongi.today"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/ongi/ongibe/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/ongi/ongibe/global/security/filter/JwtAuthenticationFilter.java
@@ -25,6 +25,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        String path = request.getRequestURI();
+
+        if (path.startsWith("/api/auth")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String authHeader = request.getHeader("Authorization");
 
         if (authHeader != null && authHeader.startsWith("Bearer ")) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #206 HotFox

## 📝작업 내용

> JWT Filter chain에 /api/auth 통과하도록 로직 구현