### PR TITLE
Feat/#78 조회용 presigned url 구현

### DIFF
--- a/src/main/java/ongi/ongibe/domain/album/dto/MonthlyAlbumResponseDTO.java
+++ b/src/main/java/ongi/ongibe/domain/album/dto/MonthlyAlbumResponseDTO.java
@@ -17,11 +17,11 @@ public record MonthlyAlbumResponseDTO(
             @Schema(description = "앨범 생성 일시") LocalDateTime createdAt,
             @Schema(description = "앨범 멤버들의 프로필 이미지 URL 목록") List<String> memberProfileImageURL
     ) {
-        public static AlbumInfo of(Album album) {
+        public static AlbumInfo of(Album album, String presignedThumbnailUrl) {
             return new AlbumInfo(
                     album.getId(),
                     album.getName(),
-                    album.getThumbnailPicture() != null ? album.getThumbnailPicture().getPictureURL() : null,
+                    presignedThumbnailUrl,
                     album.getCreatedAt(),
                     album.getUserAlbums().stream()
                             .map(ua -> ua.getUser().getProfileImage())

--- a/src/main/java/ongi/ongibe/domain/album/entity/Album.java
+++ b/src/main/java/ongi/ongibe/domain/album/entity/Album.java
@@ -48,6 +48,7 @@ public class Album {
     @JoinColumn(name = "thumbnail_picture_id")
     private Picture thumbnailPicture;
 
+    @Column(length = 10)
     private String name;
 
     @CreationTimestamp

--- a/src/main/java/ongi/ongibe/domain/album/entity/Picture.java
+++ b/src/main/java/ongi/ongibe/domain/album/entity/Picture.java
@@ -52,6 +52,8 @@ public class Picture {
 
     @Column(length = 512)
     private String pictureURL;
+    @Column(nullable = true)
+    private String s3Key;
 
     @Column(length = 512)
     private String tag;

--- a/src/main/java/ongi/ongibe/domain/album/entity/Picture.java
+++ b/src/main/java/ongi/ongibe/domain/album/entity/Picture.java
@@ -71,10 +71,10 @@ public class Picture {
 
     private LocalDateTime deletedAt;
 
-    public AlbumDetailResponseDTO.PictureInfo toPictureInfo() {
+    public AlbumDetailResponseDTO.PictureInfo toPictureInfo(String presignedUrl) {
         return new AlbumDetailResponseDTO.PictureInfo(
                 id,
-                pictureURL,
+                presignedUrl,
                 latitude,
                 longitude,
                 tag,
@@ -85,10 +85,10 @@ public class Picture {
         );
     }
 
-    public AlbumSummaryResponseDTO toAlbumSummaryResponseDTO() {
+    public AlbumSummaryResponseDTO toAlbumSummaryResponseDTO(String presignedUrl) {
         return new AlbumSummaryResponseDTO(
                 id,
-                pictureURL,
+                presignedUrl,
                 latitude,
                 longitude
         );

--- a/src/main/java/ongi/ongibe/domain/album/service/AlbumService.java
+++ b/src/main/java/ongi/ongibe/domain/album/service/AlbumService.java
@@ -85,23 +85,40 @@ public class AlbumService {
                 .filter(album -> album.getCreatedAt().isAfter(startOfMonth.minusNanos(1)) &&
                         album.getCreatedAt().isBefore(endOfMonth.plusNanos(1)))
                 .map(album -> {
-                    String thumbnailKey = album.getThumbnailPicture() != null ? album.getThumbnailPicture().getPictureURL() : null;
-                    String presignedUrl = (thumbnailKey != null)
-                            ? presignedUrlService.generateGetPresignedUrl(thumbnailKey)
+                    String fullUrl = album.getThumbnailPicture() != null ? album.getThumbnailPicture().getPictureURL() : null;
+                    String key = null;
+                    if (fullUrl != null){
+                        if (album.getThumbnailPicture().getS3Key() != null){
+                            key = album.getThumbnailPicture().getS3Key();
+                        } else {
+                            key = presignedUrlService.extractS3Key(fullUrl);
+                            album.getThumbnailPicture().setS3Key(key);
+                            pictureRepository.save(album.getThumbnailPicture());
+                        }
+                    }
+                    String presignedUrl = key != null
+                            ? presignedUrlService.generateGetPresignedUrl(key)
                             : null;
-
                     return AlbumInfo.of(album, presignedUrl);
                 }).toList();
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public BaseApiResponse<List<AlbumSummaryResponseDTO>> getAlbumSummary(Long albumId) {
         Album album = getAlbumIfMember(albumId);
 
         Map<Place, Picture> bestPictureOfPlace = getBestPictureOfPlace(album);
 
         List<AlbumSummaryResponseDTO> response = bestPictureOfPlace.values().stream()
-                .map(Picture::toAlbumSummaryResponseDTO)
+                .map(picture -> {
+                    String key = picture.getS3Key() != null ? picture.getS3Key() : presignedUrlService.extractS3Key(picture.getPictureURL());
+                    if (picture.getS3Key() == null) {
+                        picture.setS3Key(key);
+                        pictureRepository.save(picture);
+                    }
+                    String presignedUrl = presignedUrlService.generateGetPresignedUrl(key);
+                    return picture.toAlbumSummaryResponseDTO(presignedUrl);
+                })
                 .toList();
 
         return BaseApiResponse.success("ALBUM_SUMMARY_SUCCESS", "앨범 요약 조회 성공", response);
@@ -120,12 +137,20 @@ public class AlbumService {
         return bestPictureOfPlace;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public BaseApiResponse<AlbumDetailResponseDTO> getAlbumDetail(Long albumId) {
         Album album = getAlbumIfMember(albumId);
-
+        log.info(presignedUrlService.generateGetPresignedUrl("KakaoTalk_Photo_2025-02-17-14-16-38 008.jpeg"));
         List<AlbumDetailResponseDTO.PictureInfo> pictureInfos = album.getPictures().stream()
-                .map(Picture::toPictureInfo)
+                .map(picture -> {
+                    String key = picture.getS3Key() != null ?
+                            picture.getS3Key() : presignedUrlService.extractS3Key(picture.getPictureURL());
+                    picture.setS3Key(key);
+                    pictureRepository.save(picture);
+                    System.out.println("DEBUG 진입: key = " + key);
+                    String presignedUrl = presignedUrlService.generateGetPresignedUrl(key);
+                    return picture.toPictureInfo(presignedUrl);
+                })
                 .toList();
 
         AlbumDetailResponseDTO responseDTO = new AlbumDetailResponseDTO(
@@ -300,6 +325,7 @@ public class AlbumService {
                         .pictureURL(dto.pictureUrl())
                         .latitude(dto.latitude())
                         .longitude(dto.longitude())
+                        .s3Key(presignedUrlService.extractS3Key(dto.pictureUrl()))
                         .build())
                 .toList();
     }

--- a/src/main/java/ongi/ongibe/global/s3/PresignedExceptionHandler.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedExceptionHandler.java
@@ -1,0 +1,21 @@
+package ongi.ongibe.global.s3;
+
+import ongi.ongibe.common.BaseApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class PresignedExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<BaseApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(BaseApiResponse.<Void>builder()
+                        .code("INVALID_EXTENSION")
+                        .message(ex.getMessage())
+                        .data(null)
+                        .build());
+    }
+}

--- a/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
@@ -73,7 +73,7 @@ public class PresignedUrlService {
                 .build();
     }
 
-    public String generatePresignedUrl(String key) {
+    public String generateGetPresignedUrl(String key) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)

--- a/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import ongi.ongibe.common.BaseApiResponse;
 import ongi.ongibe.global.s3.dto.PresignedUrlRequestDTO;
 import ongi.ongibe.global.s3.dto.PresignedUrlRequestDTO.PictureInfo;
@@ -19,6 +20,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PresignedUrlService {
@@ -91,7 +93,8 @@ public class PresignedUrlService {
     public String extractS3Key(String fullUrl) {
         try {
             URI uri = URI.create(fullUrl);
-            String path = uri.getPath(); // 예: "/pictures/a.jpg" 또는 "/bucket-name/pictures/a.jpg"
+            String path = uri.getRawPath(); // 예: "/pictures/a.jpg" 또는 "/bucket-name/pictures/a.jpg"
+            log.debug("path: {}", path);
 
             // path 앞에 '/'가 항상 붙기 때문에 제거
             if (path.startsWith("/")) {

--- a/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
@@ -13,7 +13,9 @@ import ongi.ongibe.global.s3.dto.PresignedUrlRequestDTO.PictureInfo;
 import ongi.ongibe.global.s3.dto.PresignedUrlResponseDTO;
 import ongi.ongibe.global.s3.dto.PresignedUrlResponseDTO.PresignedFile;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -37,8 +39,12 @@ public class PresignedUrlService {
         List<PresignedFile> result = request.pictures().stream()
                 .map(picture -> {
                     String key = picture.pictureName();
+                    String type = picture.pictureType();
+                    if (!List.of("jpg", "jpeg", "png", "webp").contains(type.toLowerCase())) {
+                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 확장자입니다: " + type);
+                    }
 
-                    PutObjectRequest putObjectRequest = getObjectRequest(picture.pictureType(), key);
+                    PutObjectRequest putObjectRequest = getObjectRequest(type, key);
 
                     PutObjectPresignRequest presignRequest = getPresignRequest(putObjectRequest);
 

--- a/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
@@ -88,19 +88,24 @@ public class PresignedUrlService {
     }
 
 
-    private String extractS3Key(String fullUrl){
+    public String extractS3Key(String fullUrl) {
         try {
             URI uri = URI.create(fullUrl);
-            URL url = uri.toURL();
-            String path = url.getPath();
+            String path = uri.getPath(); // 예: "/pictures/a.jpg" 또는 "/bucket-name/pictures/a.jpg"
 
-            if (path.startsWith("/" + bucket + "/")) {
-                return path.substring(("/" + bucket + "/").length());
-            } else {
-                return path.substring(1); // "/pictures/a.jpg" → "pictures/a.jpg"
+            // path 앞에 '/'가 항상 붙기 때문에 제거
+            if (path.startsWith("/")) {
+                path = path.substring(1);
             }
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid S3 URL: " + fullUrl);
+
+            // 만약 path가 "bucket-name/pictures/a.jpg" 형태면 버킷 제거
+            if (path.startsWith(bucket + "/")) {
+                path = path.substring((bucket + "/").length());
+            }
+
+            return path;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid S3 URL: " + fullUrl, e);
         }
     }
 }

--- a/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
@@ -81,6 +81,37 @@ public class PresignedUrlService {
                 .build();
     }
 
+    public String generatePresignedUrl(String key) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+
+    private String extractS3Key(String fullUrl){
+        try {
+            URI uri = URI.create(fullUrl);
+            URL url = uri.toURL();
+            String path = url.getPath();
+
+            if (path.startsWith("/" + bucket + "/")) {
+                return path.substring(("/" + bucket + "/").length());
+            } else {
+                return path.substring(1); // "/pictures/a.jpg" → "pictures/a.jpg"
+            }
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid S3 URL: " + fullUrl);
+        }
+    }
+
     public String generateGetPresignedUrl(String key) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)

--- a/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
@@ -41,7 +41,7 @@ public class PresignedUrlService {
                     String key = picture.pictureName();
                     String type = picture.pictureType();
                     if (!List.of("jpg", "jpeg", "png", "webp").contains(type.toLowerCase())) {
-                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "지원하지 않는 확장자입니다: " + type);
+                        throw new IllegalArgumentException("지원하지 않는 확장자입니다: " + type);
                     }
 
                     PutObjectRequest putObjectRequest = getObjectRequest(type, key);

--- a/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
+++ b/src/main/java/ongi/ongibe/global/s3/PresignedUrlService.java
@@ -40,7 +40,7 @@ public class PresignedUrlService {
                 .map(picture -> {
                     String key = picture.pictureName();
                     String type = picture.pictureType();
-                    if (!List.of("jpg", "jpeg", "png", "webp").contains(type.toLowerCase())) {
+                    if (!List.of("image/jpg", "image/jpeg", "image/png", "image/webp").contains(type.toLowerCase())) {
                         throw new IllegalArgumentException("지원하지 않는 확장자입니다: " + type);
                     }
 
@@ -79,37 +79,6 @@ public class PresignedUrlService {
                 .key(key)
                 .contentType(pictureType)
                 .build();
-    }
-
-    public String generatePresignedUrl(String key) {
-        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                .bucket(bucket)
-                .key(key)
-                .build();
-
-        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(10))
-                .getObjectRequest(getObjectRequest)
-                .build();
-
-        return presigner.presignGetObject(presignRequest).url().toString();
-    }
-
-
-    private String extractS3Key(String fullUrl){
-        try {
-            URI uri = URI.create(fullUrl);
-            URL url = uri.toURL();
-            String path = url.getPath();
-
-            if (path.startsWith("/" + bucket + "/")) {
-                return path.substring(("/" + bucket + "/").length());
-            } else {
-                return path.substring(1); // "/pictures/a.jpg" → "pictures/a.jpg"
-            }
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("Invalid S3 URL: " + fullUrl);
-        }
     }
 
     public String generateGetPresignedUrl(String key) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #78 사진 조회 api 반환 로직 수정

## 📝작업 내용

> 사진 조회 시 presigned url 발급으로 수정
> prod에 이미 s3 url로 저장되어 있어 여기서 키를 추출하여 따로 저장하는 로직 추가
> lazy migration 적용 - 향후 batch 통해 DB 수정 예정
  * 현재는 lazy migration 적용해서 조회하는 트랜잭션마다 key를 추가로 저장하는 로직이 발생
  * 기존에 readOnly=true를 제거하여 쓰기방지했지만 lazy migration 때문에 이 어노테이션을 제거하고 변경감지를 허용(저장 액션이 발생해서 성능 저하)
  * 향후 batch 통해서 한꺼번에 key 컬럼에 반영 예정

### 스크린샷
<img width="870" alt="스크린샷 2025-05-14 07 36 34" src="https://github.com/user-attachments/assets/2e1b59c4-9c28-4639-9a51-34b843856bbc" />

<img width="844" alt="스크린샷 2025-05-14 07 41 26" src="https://github.com/user-attachments/assets/f98086b3-5da7-4d98-bc91-8e80c6996430" />

<img width="819" alt="스크린샷 2025-05-14 07 41 43" src="https://github.com/user-attachments/assets/a8b4c6a6-309a-4d9b-b48c-8ac7d12e0633" />
