### PR TITLE
fix: 유저정보 변경 시 프로필사진 조회 불가 로직 수정

### DIFF
--- a/src/main/java/ongi/ongibe/domain/album/dto/MonthlyAlbumResponseDTO.java
+++ b/src/main/java/ongi/ongibe/domain/album/dto/MonthlyAlbumResponseDTO.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import ongi.ongibe.domain.album.entity.Album;
+import ongi.ongibe.global.s3.PresignedUrlService;
 
 public record MonthlyAlbumResponseDTO(
         @Schema(description = "앨범 목록") List<AlbumInfo> albumInfo,

--- a/src/main/java/ongi/ongibe/domain/album/entity/Album.java
+++ b/src/main/java/ongi/ongibe/domain/album/entity/Album.java
@@ -48,7 +48,7 @@ public class Album {
     @JoinColumn(name = "thumbnail_picture_id")
     private Picture thumbnailPicture;
 
-    @Column(length = 10)
+    @Column(length = 12)
     private String name;
 
     @CreationTimestamp

--- a/src/main/java/ongi/ongibe/domain/album/entity/Picture.java
+++ b/src/main/java/ongi/ongibe/domain/album/entity/Picture.java
@@ -55,7 +55,7 @@ public class Picture {
     @Column(nullable = true)
     private String s3Key;
 
-    @Column(length = 512)
+    @Column(length = 20)
     private String tag;
     private boolean isDuplicated = false;
     private boolean isShaky = false;

--- a/src/main/java/ongi/ongibe/domain/album/factory/AlbumInfoFactory.java
+++ b/src/main/java/ongi/ongibe/domain/album/factory/AlbumInfoFactory.java
@@ -1,0 +1,59 @@
+package ongi.ongibe.domain.album.factory;
+
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import ongi.ongibe.domain.album.dto.MonthlyAlbumResponseDTO.AlbumInfo;
+import ongi.ongibe.domain.album.entity.Album;
+import ongi.ongibe.domain.user.repository.UserRepository;
+import ongi.ongibe.global.s3.PresignedUrlService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AlbumInfoFactory {
+
+    private final PresignedUrlService presignedUrlService;
+    private final UserRepository userRepository;
+
+    public AlbumInfo from(Album album) {
+        String thumbnailKey = Optional.ofNullable(album.getThumbnailPicture())
+                .map(p -> {
+                    if (p.getS3Key() != null) return p.getS3Key();
+                    String key = presignedUrlService.extractS3Key(p.getPictureURL());
+                    p.setS3Key(key);
+                    return key;
+                })
+                .orElse(null);
+
+        String presignedThumbnailUrl = thumbnailKey != null
+                ? presignedUrlService.generateGetPresignedUrl(thumbnailKey)
+                : null;
+
+        List<String> memberProfileImageUrls = album.getUserAlbums().stream()
+                .map(ua -> {
+                    String rawUrl = ua.getUser().getProfileImage();
+                    if (rawUrl == null) return null;
+                    if (!rawUrl.contains("amazonaws.com")) {
+                        return rawUrl;
+                    }
+                    if (ua.getUser().getS3Key() != null) {
+                        return presignedUrlService.generateGetPresignedUrl(ua.getUser().getS3Key());
+                    }
+                    String key = presignedUrlService.extractS3Key(rawUrl);
+                    ua.getUser().setS3Key(key);
+                    userRepository.save(ua.getUser());
+                    return presignedUrlService.generateGetPresignedUrl(key);
+                })
+                .toList();
+
+        return new AlbumInfo(
+                album.getId(),
+                album.getName(),
+                presignedThumbnailUrl,
+                album.getCreatedAt(),
+                memberProfileImageUrls
+        );
+    }
+}
+

--- a/src/main/java/ongi/ongibe/domain/album/service/AlbumService.java
+++ b/src/main/java/ongi/ongibe/domain/album/service/AlbumService.java
@@ -25,6 +25,7 @@ import ongi.ongibe.domain.album.entity.Album;
 import ongi.ongibe.domain.album.entity.Picture;
 import ongi.ongibe.domain.album.event.AlbumEvent;
 import ongi.ongibe.domain.album.exception.AlbumException;
+import ongi.ongibe.domain.album.factory.AlbumInfoFactory;
 import ongi.ongibe.domain.album.repository.PictureRepository;
 import ongi.ongibe.domain.album.repository.RedisInviteTokenRepository;
 import ongi.ongibe.domain.notification.event.AlbumCreatedNotificationEvent;
@@ -58,11 +59,12 @@ public class AlbumService {
     private final RedisInviteTokenRepository redisInviteTokenRepository;
     private final UserRepository userRepository;
     private final PresignedUrlService presignedUrlService;
+    private final AlbumInfoFactory albumInfoFactory;
 
     private static final String INVITE_LINK_PREFIX = "https://ongi.com/invite?token=";
     private static final int MAX_PICTURE_SIZE = 10;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public BaseApiResponse<MonthlyAlbumResponseDTO> getMonthlyAlbum(String yearMonth) {
         User user = securityUtil.getCurrentUser();
         List<UserAlbum> userAlbumList = userAlbumRepository.findAllByUser(user);
@@ -86,23 +88,8 @@ public class AlbumService {
                 .map(UserAlbum::getAlbum)
                 .filter(album -> album.getCreatedAt().isAfter(startOfMonth.minusNanos(1)) &&
                         album.getCreatedAt().isBefore(endOfMonth.plusNanos(1)))
-                .map(album -> {
-                    String fullUrl = album.getThumbnailPicture() != null ? album.getThumbnailPicture().getPictureURL() : null;
-                    String key = null;
-                    if (fullUrl != null){
-                        if (album.getThumbnailPicture().getS3Key() != null){
-                            key = album.getThumbnailPicture().getS3Key();
-                        } else {
-                            key = presignedUrlService.extractS3Key(fullUrl);
-                            album.getThumbnailPicture().setS3Key(key);
-                            pictureRepository.save(album.getThumbnailPicture());
-                        }
-                    }
-                    String presignedUrl = key != null
-                            ? presignedUrlService.generateGetPresignedUrl(key)
-                            : null;
-                    return AlbumInfo.of(album, presignedUrl);
-                }).toList();
+                .map(albumInfoFactory::from)
+                .toList();
     }
 
     @Transactional

--- a/src/main/java/ongi/ongibe/domain/user/entity/User.java
+++ b/src/main/java/ongi/ongibe/domain/user/entity/User.java
@@ -65,6 +65,9 @@ public class User {
     @Column(nullable = false, length = 512)
     private String profileImage;
 
+    @Column
+    private String s3Key;
+
     @Column(length = 320)
     private String email;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #221 엔티티 제약조건 재설정

## 📝작업 내용

> 엔티티 제약조건 재설정
> user 조회 시 user profile image도 presigned url로 조회하게 수정