### PR TITLE
Feat/#196

### DIFF
--- a/src/main/java/ongi/ongibe/global/exception/handler/SecurityUtilExceptionHandler.java
+++ b/src/main/java/ongi/ongibe/global/exception/handler/SecurityUtilExceptionHandler.java
@@ -1,5 +1,6 @@
 package ongi.ongibe.global.exception.handler;
 
+import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import ongi.ongibe.common.BaseApiResponse;
 import ongi.ongibe.global.exception.SecurityUtilException;
@@ -14,6 +15,7 @@ public class SecurityUtilExceptionHandler {
 
     @ExceptionHandler(SecurityUtilException.class)
     public ResponseEntity<BaseApiResponse<Void>> handleSecurityUtilException(SecurityUtilException e) {
+        Sentry.captureException(e);
         log.warn("인증정보 예외 발생 : {}", e.getMessage());
         String code = switch (e.getStatusCode()){
             case HttpStatus.NOT_FOUND -> "USER_NOT_FOUND";

--- a/src/main/java/ongi/ongibe/global/exception/handler/TokenExceptionHandler.java
+++ b/src/main/java/ongi/ongibe/global/exception/handler/TokenExceptionHandler.java
@@ -1,5 +1,6 @@
 package ongi.ongibe.global.exception.handler;
 
+import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import ongi.ongibe.common.BaseApiResponse;
 import ongi.ongibe.global.exception.InvalidTokenException;
@@ -16,6 +17,7 @@ public class TokenExceptionHandler {
 
     @ExceptionHandler(TokenParsingException.class)
     public ResponseEntity<BaseApiResponse<Void>> handleTokenParsingException(TokenParsingException e) {
+        Sentry.captureException(e);
         log.warn("토큰 파싱 에러 : {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
@@ -26,6 +28,7 @@ public class TokenExceptionHandler {
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<BaseApiResponse<Void>> handleInvalidTokenException(InvalidTokenException e) {
+        Sentry.captureException(e);
         log.warn("토큰 검증 에러 : {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
@@ -36,6 +39,7 @@ public class TokenExceptionHandler {
 
     @ExceptionHandler(TokenNotFoundException.class)
     public ResponseEntity<BaseApiResponse<Void>> handelTokenNotFoundException(TokenNotFoundException e){
+        Sentry.captureException(e);
         log.warn("토큰을 찾을 수 없음 : {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)

--- a/src/main/java/ongi/ongibe/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/ongi/ongibe/global/security/filter/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         log.info("요청 경로: {}", path);
         log.info("Authorization 헤더: {}", authHeader);
 
-        if (path.startsWith("/api/auth")){
+        if (path.startsWith("/api/auth") || path.startsWith("/sentry/")) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -49,7 +49,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
+
             } catch (ResponseStatusException e) {
+                io.sentry.Sentry.captureException(e);
+
                 response.setContentType("application/json");
                 response.setStatus(e.getStatusCode().value());
                 String message = e.getReason();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #196 

## 📝작업 내용

* JwtAuthenticationFilter에서 /sentry/ 경로 인증 제외 처리 추가
* 필터 내부 ResponseStatusException 발생 시 Sentry 예외 수집 추가
* TokenExceptionHandler, SecurityUtilExceptionHandler에 Sentry.captureException() 적용
* 모든 인증/토큰 관련 예외를 Sentry에서 추적 가능하도록 개선

