### PR TITLE
Fix/#211

### DIFF
--- a/src/main/java/ongi/ongibe/domain/album/event/AlbumRetryEvent.java
+++ b/src/main/java/ongi/ongibe/domain/album/event/AlbumRetryEvent.java
@@ -1,0 +1,8 @@
+package ongi.ongibe.domain.album.event;
+
+import java.util.List;
+
+public record AlbumRetryEvent(
+        Long albumId,
+        List<String> pictureS3Keys
+) {}

--- a/src/main/java/ongi/ongibe/domain/album/schedule/AlbumAiRetryScheduler.java
+++ b/src/main/java/ongi/ongibe/domain/album/schedule/AlbumAiRetryScheduler.java
@@ -7,6 +7,7 @@ import ongi.ongibe.domain.album.AlbumProcessState;
 import ongi.ongibe.domain.album.entity.Album;
 import ongi.ongibe.domain.album.entity.Picture;
 import ongi.ongibe.domain.album.event.AlbumEvent;
+import ongi.ongibe.domain.album.event.AlbumRetryEvent;
 import ongi.ongibe.domain.album.repository.AlbumRepository;
 import ongi.ongibe.domain.album.repository.PictureRepository;
 import org.springframework.context.ApplicationEventPublisher;
@@ -36,7 +37,7 @@ public class AlbumAiRetryScheduler {
 
                 album.setProcessState(AlbumProcessState.IN_PROGRESS);
                 log.info("[AI 재시도] 앨범 ID: {}, 사진 수: {}", album.getId(), pictureKeys.size());
-                eventPublisher.publishEvent(new AlbumEvent(album.getId(), pictureKeys));
+                eventPublisher.publishEvent(new AlbumRetryEvent(album.getId(), pictureKeys));
             } catch (Exception e) {
                 log.error("[AI 재시도 실패] 앨범 ID: {}, message: {}", album.getId(), e.getMessage(), e);
                 album.setProcessState(AlbumProcessState.FAILED);

--- a/src/main/java/ongi/ongibe/global/eventlistener/AlbumCreataedRetryEventListener.java
+++ b/src/main/java/ongi/ongibe/global/eventlistener/AlbumCreataedRetryEventListener.java
@@ -1,0 +1,20 @@
+package ongi.ongibe.global.eventlistener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ongi.ongibe.domain.album.event.AlbumRetryEvent;
+import ongi.ongibe.domain.album.service.AlbumProcessService;
+import org.springframework.scheduling.annotation.Async;
+
+@Slf4j
+@RequiredArgsConstructor
+public class AlbumCreataedRetryEventListener {
+
+    private final AlbumProcessService albumProcessService;
+
+    @Async
+    public void handledAlbumCreatedRetry(AlbumRetryEvent event) {
+        log.info("event received: {}", event.albumId());
+        albumProcessService.processAlbumAsync(event.albumId(), event.pictureS3Keys());
+    }
+}

--- a/src/main/java/ongi/ongibe/global/eventlistener/AlbumCreataedRetryEventListener.java
+++ b/src/main/java/ongi/ongibe/global/eventlistener/AlbumCreataedRetryEventListener.java
@@ -5,8 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import ongi.ongibe.domain.album.event.AlbumRetryEvent;
 import ongi.ongibe.domain.album.service.AlbumProcessService;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor
 public class AlbumCreataedRetryEventListener {
 
@@ -14,7 +16,7 @@ public class AlbumCreataedRetryEventListener {
 
     @Async
     public void handledAlbumCreatedRetry(AlbumRetryEvent event) {
-        log.info("event received: {}", event.albumId());
+        log.info("retry event received: {}", event.albumId());
         albumProcessService.processAlbumAsync(event.albumId(), event.pictureS3Keys());
     }
 }

--- a/src/main/java/ongi/ongibe/global/eventlistener/AlbumCreatedRetryEventListener.java
+++ b/src/main/java/ongi/ongibe/global/eventlistener/AlbumCreatedRetryEventListener.java
@@ -4,17 +4,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ongi.ongibe.domain.album.event.AlbumRetryEvent;
 import ongi.ongibe.domain.album.service.AlbumProcessService;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class AlbumCreataedRetryEventListener {
+public class AlbumCreatedRetryEventListener {
 
     private final AlbumProcessService albumProcessService;
 
     @Async
+    @EventListener
     public void handledAlbumCreatedRetry(AlbumRetryEvent event) {
         log.info("retry event received: {}", event.albumId());
         albumProcessService.processAlbumAsync(event.albumId(), event.pictureS3Keys());


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #209 

## 📝작업 내용

> 이벤트리스너 오류 해결 목적 재사용하지 않고 별도 이벤트리스너로 분리
  - 미작동 원인 : 트랜잭션이 아닌 메서드에서 @TransactionalEventListener 사용
