### PR TITLE
fix : flyway cloud build에서 실행되도록 수정

### DIFF
--- a/.github/workflows/dev_deploy.yaml
+++ b/.github/workflows/dev_deploy.yaml
@@ -27,19 +27,6 @@ jobs:
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
-      - name: Load Flyway Secrets
-        run: |
-          echo "FLYWAY_DB_URL=$(gcloud secrets versions access latest --secret=flyway-url-dev)" >> $GITHUB_ENV
-          echo "FLYWAY_DB_USER=$(gcloud secrets versions access latest --secret=flyway-user-dev)" >> $GITHUB_ENV
-          echo "FLYWAY_DB_PASSWORD=$(gcloud secrets versions access latest --secret=flyway-password-dev)" >> $GITHUB_ENV
-
-      - name: Flyway Migrate (DEV)
-        run: |
-          ./gradlew flywayMigrate \
-            -Dflyway.url=${{ env.FLYWAY_DB_URL }} \
-            -Dflyway.user=${{ env.FLYWAY_DB_USER }} \
-            -Dflyway.password=${{ env.FLYWAY_DB_PASSWORD }}
-
       - name: Build Application
         run: ./gradlew clean build -x test
 
@@ -53,7 +40,6 @@ jobs:
           docker push asia-northeast3-docker.pkg.dev/dev-ongi-3-tier/dev-ongi-spring-repo/backend:$TAG
 
       - name: Trigger Cloud Build Deploy
-
         run: |
           TAG=dev-$(date +%Y%m%d)-pr${{ github.event.pull_request.number }}
           gcloud builds submit .gcp/dev-deploy \

--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -1,6 +1,10 @@
+substitutions:
+  _IMAGE_TAG: dev-latest
+  _SSH_KEYS: ""
+
 steps:
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: 'load-secrets'
+    id: load-secrets
     entrypoint: bash
     args:
       - -c
@@ -11,6 +15,26 @@ steps:
         FLYWAY_URL=$(gcloud secrets versions access latest --secret=flyway-url-dev)
         FLYWAY_USER=$(gcloud secrets versions access latest --secret=flyway-user-dev)
         FLYWAY_PASSWORD=$(gcloud secrets versions access latest --secret=flyway-password-dev)
+
+        echo "FLYWAY_URL=$FLYWAY_URL" >> /workspace/.env
+        echo "FLYWAY_USER=$FLYWAY_USER" >> /workspace/.env
+        echo "FLYWAY_PASSWORD=$FLYWAY_PASSWORD" >> /workspace/.env
+        echo "DB_URL=$DB_URL" >> /workspace/.env
+        echo "DB_USER=$DB_USER" >> /workspace/.env
+        echo "DB_PASSWORD=$DB_PASSWORD" >> /workspace/.env
+        export DB_URL DB_USER DB_PASSWORD FLYWAY_URL FLYWAY_USER FLYWAY_PASSWORD
+
+        ./gradlew flywayMigrate \
+          -Dflyway.url=$FLYWAY_URL \
+          -Dflyway.user=$FLYWAY_USER \
+          -Dflyway.password=$FLYWAY_PASSWORD
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: deploy-backend
+    entrypoint: bash
+    args:
+      - -c
+      - |
         REDIS_SERVER_URL=$(gcloud secrets versions access latest --secret=redis_server_url)
         KAKAO_CLIENT_ID=$(gcloud secrets versions access latest --secret=kakao-client-id)
         AWS_ACCESS_KEY_ID=$(gcloud secrets versions access latest --secret=aws-access-key-id)
@@ -20,8 +44,7 @@ steps:
         JWT_SECRET=$(gcloud secrets versions access latest --secret=jwt-secret)
         AI_SERVER_URL=$(gcloud secrets versions access latest --secret=ai-server-url-dev)
 
-        export DB_URL DB_USER DB_PASSWORD FLYWAY_URL FLYWAY_USER FLYWAY_PASSWORD \
-               REDIS_SERVER_URL KAKAO_CLIENT_ID AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
+        export REDIS_SERVER_URL KAKAO_CLIENT_ID AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
                AWS_REGION S3_BUCKET_NAME JWT_SECRET AI_SERVER_URL
 
         TEMPLATE_NAME=ongi-dev-template-${_IMAGE_TAG}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #262

📝 작업 내용
- GitHub Actions에서 Flyway 마이그레이션을 제거하고 Cloud Build에서 Flyway 실행하도록 수정
- GitHub Actions의 cloudbuild-dev.yaml 호출 로직 유지
- 내부 DB (10.0.30.3)에 접근할 수 없어 발생하던 Communications link failure 문제 해결
- cloudbuild-dev.yaml에 Flyway 관련 secrets 로딩 및 ./gradlew flywayMigrate 실행 추가
