### PR TITLE
fix : ci/cd 구조 수정

### DIFF
--- a/cloudbuild-dev.yaml
+++ b/cloudbuild-dev.yaml
@@ -4,49 +4,11 @@ substitutions:
 
 steps:
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    id: load-secrets
-    entrypoint: bash
-    args:
-      - -c
-      - |
-        DB_URL=$(gcloud secrets versions access latest --secret=db-url-dev)
-        DB_USER=$(gcloud secrets versions access latest --secret=db-user-dev)
-        DB_PASSWORD=$(gcloud secrets versions access latest --secret=db-password-dev)
-        FLYWAY_URL=$(gcloud secrets versions access latest --secret=flyway-url-dev)
-        FLYWAY_USER=$(gcloud secrets versions access latest --secret=flyway-user-dev)
-        FLYWAY_PASSWORD=$(gcloud secrets versions access latest --secret=flyway-password-dev)
-
-        echo "FLYWAY_URL=$FLYWAY_URL" >> /workspace/.env
-        echo "FLYWAY_USER=$FLYWAY_USER" >> /workspace/.env
-        echo "FLYWAY_PASSWORD=$FLYWAY_PASSWORD" >> /workspace/.env
-        echo "DB_URL=$DB_URL" >> /workspace/.env
-        echo "DB_USER=$DB_USER" >> /workspace/.env
-        echo "DB_PASSWORD=$DB_PASSWORD" >> /workspace/.env
-        export DB_URL DB_USER DB_PASSWORD FLYWAY_URL FLYWAY_USER FLYWAY_PASSWORD
-
-        ./gradlew flywayMigrate \
-          -Dflyway.url=$FLYWAY_URL \
-          -Dflyway.user=$FLYWAY_USER \
-          -Dflyway.password=$FLYWAY_PASSWORD
-
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: deploy-backend
     entrypoint: bash
     args:
       - -c
       - |
-        REDIS_SERVER_URL=$(gcloud secrets versions access latest --secret=redis_server_url)
-        KAKAO_CLIENT_ID=$(gcloud secrets versions access latest --secret=kakao-client-id)
-        AWS_ACCESS_KEY_ID=$(gcloud secrets versions access latest --secret=aws-access-key-id)
-        AWS_SECRET_ACCESS_KEY=$(gcloud secrets versions access latest --secret=aws-secret-access-dev)
-        AWS_REGION=$(gcloud secrets versions access latest --secret=aws-region)
-        S3_BUCKET_NAME=$(gcloud secrets versions access latest --secret=s3-bucket-name-dev)
-        JWT_SECRET=$(gcloud secrets versions access latest --secret=jwt-secret)
-        AI_SERVER_URL=$(gcloud secrets versions access latest --secret=ai-server-url-dev)
-
-        export REDIS_SERVER_URL KAKAO_CLIENT_ID AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY \
-               AWS_REGION S3_BUCKET_NAME JWT_SECRET AI_SERVER_URL
-
         TEMPLATE_NAME=ongi-dev-template-${_IMAGE_TAG}
         IMAGE=asia-northeast3-docker.pkg.dev/dev-ongi-3-tier/dev-ongi-spring-repo/backend:${_IMAGE_TAG}
 
@@ -57,7 +19,7 @@ steps:
           --image-family=cos-stable \
           --image-project=cos-cloud \
           --container-image=$IMAGE \
-          --container-env=SPRING_PROFILES_ACTIVE=dev,DB_URL=$DB_URL,DB_USER=$DB_USER,DB_PASSWORD=$DB_PASSWORD,FLYWAY_URL=$FLYWAY_URL,FLYWAY_USER=$FLYWAY_USER,FLYWAY_PASSWORD=$FLYWAY_PASSWORD,REDIS_SERVER_URL=$REDIS_SERVER_URL,KAKAO_CLIENT_ID=$KAKAO_CLIENT_ID,AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY,AWS_REGION=$AWS_REGION,S3_BUCKET_NAME=$S3_BUCKET_NAME,JWT_SECRET=$JWT_SECRET,AI_SERVER_URL=$AI_SERVER_URL \
+          --container-env=SPRING_PROFILES_ACTIVE=dev \
           --metadata=ssh-keys="${_SSH_KEYS}" \
           --service-account=github-cd-builder@dev-ongi-3-tier.iam.gserviceaccount.com \
           --scopes=https://www.googleapis.com/auth/cloud-platform \

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     name: ongiBE
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
+  config:
+    import: "sm://"
 
 server:
   port: 8080


### PR DESCRIPTION
### ✅ 주요 변경 사항
- Spring Boot `application.yaml`에 `sm://` 기반 Secret Manager 연동 적용
- GitHub Actions에서 더 이상 `.env`나 export 없이 이미지 빌드 및 배포
- Cloud Build에서도 환경변수는 Secret Manager에서 런타임에 자동 주입
- GCS 버킷은 미리 생성하여 Cloud Build submit 오류 방지

### 🔐 보안 강화
- 민감 정보는 모두 GCP Secret Manager에 저장되고 실행 시 로드됨
- .env 파일 삭제로 로컬 및 CI/CD 환경에 민감 정보가 남지 않음
- 서비스 계정 최소 권한 원칙 적용 가능 (`roles/secretmanager.secretAccessor` 등)

### 📌 참고
- `.gcp/dev-deploy/cloudbuild-dev.yaml`: container-env 최소화
- `application.yaml`: sm:// 기반 Secret Manager 값 매핑

> 실 운영 배포 단계에서도 동일한 패턴 확장 가능
