### PR TITLE
Fix/#365 유저 사진 변경 시 캐시 재작성하도록 수정

### DIFF
--- a/src/main/java/ongi/ongibe/cache/album/AlbumCacheService.java
+++ b/src/main/java/ongi/ongibe/cache/album/AlbumCacheService.java
@@ -66,6 +66,13 @@ public class AlbumCacheService {
 
     }
 
+    public void refreshAllMonthlyAlbumCache(Long userId) {
+        List<String> yearMonths = userAlbumRepository.findAllYearMonthsByUserId(userId);
+        for (String yearMonth : yearMonths) {
+            refreshMonthlyAlbum(userId, yearMonth);
+        }
+    }
+
     private MonthlyAlbumResponseDTO buildMonthlyAlbumResponse(User user, String yearMonth) {
         List<UserAlbum> userAlbumList = userAlbumRepository.findAllByUser(user);
         List<AlbumInfo> albumInfos = getAlbumInfos(userAlbumList, yearMonth);
@@ -75,4 +82,5 @@ public class AlbumCacheService {
 
         return new MonthlyAlbumResponseDTO(albumInfos, nextYearMonth, hasNext);
     }
+
 }

--- a/src/main/java/ongi/ongibe/cache/event/UserProfileUpdateCacheEvent.java
+++ b/src/main/java/ongi/ongibe/cache/event/UserProfileUpdateCacheEvent.java
@@ -1,0 +1,5 @@
+package ongi.ongibe.cache.event;
+
+public record UserProfileUpdateCacheEvent(
+   Long userId
+) {}

--- a/src/main/java/ongi/ongibe/domain/album/repository/UserAlbumRepository.java
+++ b/src/main/java/ongi/ongibe/domain/album/repository/UserAlbumRepository.java
@@ -31,4 +31,13 @@ public interface UserAlbumRepository extends JpaRepository<UserAlbum, Long> {
     List<UserAlbum> findAllByAlbum(Album album);
 
     List<UserAlbum> findAllByAlbumAndUser(Album album, User user);
+
+    @Query("""
+    select distinct function('DATE_FORMAT', a.createdAt, '%Y-%m') 
+    from UserAlbum ua
+    join ua.album a
+    where ua.user.id = :userId and ua.deletedAt is null and a.deletedAt is null
+    """)
+    List<String> findAllYearMonthsByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/ongi/ongibe/domain/user/service/UserService.java
+++ b/src/main/java/ongi/ongibe/domain/user/service/UserService.java
@@ -14,6 +14,8 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import ongi.ongibe.cache.album.AlbumCacheService;
+import ongi.ongibe.cache.event.UserProfileUpdateCacheEvent;
 import ongi.ongibe.cache.user.UserCacheService;
 import ongi.ongibe.common.BaseApiResponse;
 import ongi.ongibe.domain.album.dto.UserUpdateRequestDTO;
@@ -32,6 +34,7 @@ import ongi.ongibe.domain.user.repository.UserRepository;
 import ongi.ongibe.global.s3.PresignedUrlService;
 import ongi.ongibe.global.security.util.SecurityUtil;
 import ongi.ongibe.util.DateUtil;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -47,6 +50,7 @@ public class UserService {
     private final PresignedUrlService presignedUrlService;
     private final SecurityUtil securityUtil;
     private final UserCacheService userCacheService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public BaseApiResponse<UserTotalStateResponseDTO> getUserTotalState(){
@@ -108,6 +112,7 @@ public class UserService {
         String key = presignedUrlService.extractS3Key(request.profileImageURL());
         user.setS3Key(key);
         userRepository.save(user);
+        eventPublisher.publishEvent(new UserProfileUpdateCacheEvent(userId));
         UserInfoResponseDTO response = new UserInfoResponseDTO(user.getId(), user.getNickname(), user.getProfileImage(), 300);
         return BaseApiResponse.success("USER_UPDATE_SUCCESS", "유저 정보 수정 완료했습니다.", response);
     }

--- a/src/main/java/ongi/ongibe/global/eventlistener/UserProfileUpdateCacheEventListener.java
+++ b/src/main/java/ongi/ongibe/global/eventlistener/UserProfileUpdateCacheEventListener.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ongi.ongibe.cache.album.AlbumCacheService;
 import ongi.ongibe.cache.event.UserProfileUpdateCacheEvent;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -15,6 +16,7 @@ public class UserProfileUpdateCacheEventListener {
 
     private final AlbumCacheService albumCacheService;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleUserProfileUpdateCacheEvent(UserProfileUpdateCacheEvent event){
         log.info("유저정보 변경에 따른 캐시 rewrite, userId={}", event.userId());

--- a/src/main/java/ongi/ongibe/global/eventlistener/UserProfileUpdateCacheEventListener.java
+++ b/src/main/java/ongi/ongibe/global/eventlistener/UserProfileUpdateCacheEventListener.java
@@ -1,0 +1,23 @@
+package ongi.ongibe.global.eventlistener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ongi.ongibe.cache.album.AlbumCacheService;
+import ongi.ongibe.cache.event.UserProfileUpdateCacheEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class UserProfileUpdateCacheEventListener {
+
+    private final AlbumCacheService albumCacheService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserProfileUpdateCacheEvent(UserProfileUpdateCacheEvent event){
+        log.info("유저정보 변경에 따른 캐시 rewrite, userId={}", event.userId());
+        albumCacheService.refreshAllMonthlyAlbumCache(event.userId());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #365 

## 📝작업 내용

> 기존 문제 : 프로필 사진 변경 후 메인페이지 진입 시 이전 캐시로 인해 수정 전 프로필사진이 노출되는 문제
> 해결 : 프로필 사진 변경 시 cache::monthly::{userId}::{모든 yyyy-mm}을 rewrite하도록 수정
> 추가 : rewrite 시 이벤트 발행과 비동기 작업을 통한 백그라운드 수정 구현

프로필 사진 변경 전
![스크린샷 2025-06-13 01 09 58](https://github.com/user-attachments/assets/d2f699a2-94fa-412c-ad45-795d4fff1174)

프로필 사진 변경 후
![스크린샷 2025-06-13 01 10 18](https://github.com/user-attachments/assets/f496eb98-262d-4d43-9543-4e3ce599506b)
