### PR TITLE
Fix/#371 대표사진 삭제 시 entity 조회 오류로 앨범 조회 불가 이슈 해결

### DIFF
--- a/src/main/java/ongi/ongibe/domain/album/entity/PictureFaceCluster.java
+++ b/src/main/java/ongi/ongibe/domain/album/entity/PictureFaceCluster.java
@@ -8,11 +8,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -20,6 +23,8 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "update picture_face_cluster set deleted_at = NOW() where id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public class PictureFaceCluster {
 
     @Id
@@ -33,4 +38,6 @@ public class PictureFaceCluster {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "face_cluster_id", nullable = false)
     private FaceCluster faceCluster;
+
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/ongi/ongibe/domain/album/repository/FaceClusterRepository.java
+++ b/src/main/java/ongi/ongibe/domain/album/repository/FaceClusterRepository.java
@@ -3,8 +3,12 @@ package ongi.ongibe.domain.album.repository;
 import java.util.List;
 import ongi.ongibe.domain.album.entity.FaceCluster;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FaceClusterRepository extends JpaRepository<FaceCluster, Long> {
 
     List<FaceCluster> findAllByRepresentativePicture_Album_Id(Long representativePictureAlbumId);
+
+    @Query("SELECT fc.representativePicture.id FROM FaceCluster fc")
+    List<Long> findAllRepresentativePictureIds();
 }

--- a/src/main/java/ongi/ongibe/domain/album/repository/PictureFaceClusterRepository.java
+++ b/src/main/java/ongi/ongibe/domain/album/repository/PictureFaceClusterRepository.java
@@ -1,11 +1,19 @@
 package ongi.ongibe.domain.album.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import ongi.ongibe.domain.album.entity.FaceCluster;
 import ongi.ongibe.domain.album.entity.PictureFaceCluster;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PictureFaceClusterRepository extends JpaRepository<PictureFaceCluster, Long> {
 
     List<PictureFaceCluster> findAllByFaceCluster(FaceCluster faceCluster);
+
+    @Query("""
+    update PictureFaceCluster pfc set pfc.deletedAt = :now where pfc.picture.id in :pictureIds
+    """)
+    void deleteAllByPictureIds(@Param("now")LocalDateTime now, @Param("pictureIds") List<Long> pictureIds);
 }

--- a/src/main/java/ongi/ongibe/domain/album/repository/PictureFaceClusterRepository.java
+++ b/src/main/java/ongi/ongibe/domain/album/repository/PictureFaceClusterRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import ongi.ongibe.domain.album.entity.FaceCluster;
 import ongi.ongibe.domain.album.entity.PictureFaceCluster;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,6 +13,7 @@ public interface PictureFaceClusterRepository extends JpaRepository<PictureFaceC
 
     List<PictureFaceCluster> findAllByFaceCluster(FaceCluster faceCluster);
 
+    @Modifying
     @Query("""
     update PictureFaceCluster pfc set pfc.deletedAt = :now where pfc.picture.id in :pictureIds
     """)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -21,7 +21,7 @@ spring:
     url: ${FLYWAY_URL:jdbc:mysql://localhost:3306/ongi_test}
     user: ${FLYWAY_USER:root}
     password: ${FLYWAY_PASSWORD:root}
-    baseline-version: 15
+    baseline-version: 14
     baseline-on-migrate: true
 
   kakao:

--- a/src/main/resources/db/migration/V15__add_new_column_deletedat_pictureFaceCluster.sql
+++ b/src/main/resources/db/migration/V15__add_new_column_deletedat_pictureFaceCluster.sql
@@ -1,0 +1,1 @@
+ALTER TABLE picture_face_cluster ADD COLUMN deleted_at DATETIME(6) NULL;

--- a/src/test/java/ongi/ongibe/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/ongi/ongibe/domain/album/service/AlbumServiceTest.java
@@ -450,6 +450,27 @@ class AlbumServiceTest {
     }
 
     @Test
+    void deletePicture_representativePicture_삭제시도() {
+        //givne
+        Long albumId = albumRepository.findAll().stream()
+                .filter(album -> album.getName().equals("앨범 1"))
+                .findFirst()
+                .orElseThrow()
+                .getId();
+
+        when(securityUtil.getCurrentUserId()).thenReturn(testUser.getId());
+        List<Long> pictureIds = pictureRepository.findAllByAlbumId(albumId).stream()
+                .map(Picture::getId)
+                .limit(1)
+                .toList();
+
+        //when then
+        assertThatThrownBy(()->albumService.deletePictures(albumId, pictureIds))
+                .isInstanceOf(AlbumException.class)
+                .hasMessageContaining("대표 사진은 삭제할 수 없습니다.");
+    }
+
+    @Test
     void deleteAlbum_정상동작() {
         //given
         Long albumId = albumRepository.findAll().stream()

--- a/src/test/java/ongi/ongibe/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/ongi/ongibe/domain/album/service/AlbumServiceTest.java
@@ -141,7 +141,7 @@ class AlbumServiceTest {
             }
 
             /* 3. Album 생성 */
-            Picture thumbnail = pictures.getFirst();
+            Picture thumbnail = pictures.get(2);
             Album album = Album.builder()
                     .name("앨범 " + i)
                     .processState(AlbumProcessState.NOT_STARTED)
@@ -153,7 +153,7 @@ class AlbumServiceTest {
 
             /* 4. UserAlbum(OWNER) 추가 – 리스트 '교체' 아니라 '추가' */
             UserAlbum ownerUA = UserAlbum.of(testUser, album, UserAlbumRole.OWNER);
-            album.getUserAlbums().add(ownerUA);        // ✅ add 로 유지
+            album.getUserAlbums().add(ownerUA);        // add 로 유지
             testUser.getUserAlbums().add(ownerUA);     // (양방향)
 
             /* 5. 저장 – cascade 로 userAlbums, pictures 모두 저장 */
@@ -167,9 +167,9 @@ class AlbumServiceTest {
                     .build());
 
             pictureFaceClusterRepository.saveAll(List.of(
-                    PictureFaceCluster.builder().picture(pictures.get(0)).faceCluster(faceCluster).build(),
-                    PictureFaceCluster.builder().picture(pictures.get(1)).faceCluster(faceCluster).build(),
-                    PictureFaceCluster.builder().picture(pictures.get(2)).faceCluster(faceCluster).build()
+                    PictureFaceCluster.builder().picture(pictures.get(0)).faceCluster(faceCluster).deletedAt(null).build(),
+                    PictureFaceCluster.builder().picture(pictures.get(1)).faceCluster(faceCluster).deletedAt(null).build(),
+                    PictureFaceCluster.builder().picture(pictures.get(2)).faceCluster(faceCluster).deletedAt(null).build()
             ));
         }
     }
@@ -389,6 +389,7 @@ class AlbumServiceTest {
         when(securityUtil.getCurrentUserId()).thenReturn(testUser.getId());
         List<Long> pictureIds = pictureRepository.findAllByAlbumId(albumId).stream()
                 .map(Picture::getId)
+                .skip(1)
                 .limit(1)
                 .toList();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #371 

## 📝작업 내용

> representative picture 삭제 불가 로직 추가
> picture 삭제 시 picture-faceCluster softdelte 로직 추가 -> flyway 마이그레이션