### PR TITLE
Feat/#521 invite token 재활용

### DIFF
--- a/src/main/java/ongi/ongibe/domain/album/service/AlbumService.java
+++ b/src/main/java/ongi/ongibe/domain/album/service/AlbumService.java
@@ -81,6 +81,7 @@ public class AlbumService {
     private static final String INVITE_LINK_PREFIX_PROD = "https://ongi.today/invite?token=";
     private static final String INVITE_LINK_PREFIX_DEV = "https://dev.ongi.today/invite?token=";
     private static final int MAX_PICTURE_SIZE = 30;
+    private static final int MAX_ALBUM_MEMBER = 9;
 
     @Transactional(readOnly = true)
     public BaseApiResponse<MonthlyAlbumResponseDTO> getMonthlyAlbum(String yearMonth) {
@@ -447,9 +448,11 @@ public class AlbumService {
             if (validateAlbumMember(album, user.getId())){
                 throw new AlbumException(HttpStatus.BAD_REQUEST, "이미 초대된 구성원을 또다시 초대할 수 없습니다.");
             }
+            if (userAlbumRepository.findAllByAlbum(album).size() > MAX_ALBUM_MEMBER) {
+                throw new AlbumException(HttpStatus.BAD_REQUEST, "앨범 구성원 정원 초과입니다.");
+            }
             UserAlbum userAlbum = UserAlbum.of(user, album, UserAlbumRole.NORMAL);
             userAlbumRepository.save(userAlbum);
-            redisInviteTokenRepository.remove(token);
             AlbumInviteResponseDTO response = new AlbumInviteResponseDTO(tokenAlbumId,
                     album.getName());
 

--- a/src/test/java/ongi/ongibe/domain/album/service/AlbumInviteServiceTest.java
+++ b/src/test/java/ongi/ongibe/domain/album/service/AlbumInviteServiceTest.java
@@ -172,7 +172,7 @@ class AlbumInviteServiceTest {
     }
 
     @Test
-    void acceptInvite_성공() {
+    void acceptInvite_성공_한명() {
         // given
         when(redisInviteTokenRepository.existsByToken(token)).thenReturn(true);
         when(jwtTokenProvider.validateAndExtractInviteId(token)).thenReturn(albumId);
@@ -194,7 +194,6 @@ class AlbumInviteServiceTest {
         assertThat(saved.getUser()).isEqualTo(inviteTestUser);
         assertThat(saved.getAlbum()).isEqualTo(testAlbum);
         assertThat(saved.getRole()).isEqualTo(UserAlbumRole.NORMAL);
-        verify(redisInviteTokenRepository).remove(token);
     }
 
     @Test

--- a/src/test/java/ongi/ongibe/domain/album/service/AlbumInviteServiceTest.java
+++ b/src/test/java/ongi/ongibe/domain/album/service/AlbumInviteServiceTest.java
@@ -197,6 +197,29 @@ class AlbumInviteServiceTest {
     }
 
     @Test
+    void acceptInvite_구성원_초과_예외() {
+        // given
+        when(redisInviteTokenRepository.existsByToken(token)).thenReturn(true);
+        when(jwtTokenProvider.validateAndExtractInviteId(token)).thenReturn(albumId);
+        when(albumRepository.findById(albumId)).thenReturn(Optional.of(testAlbum));
+        when(securityUtil.getCurrentUser()).thenReturn(inviteTestUser);
+
+        List<UserAlbum> fullMembers = new ArrayList<>();
+        for (int i = 0; i <= 9; i++) {
+            fullMembers.add(UserAlbum.of(
+                    User.builder().id((long) i).nickname("user" + i).build(),
+                    testAlbum, UserAlbumRole.NORMAL));
+        }
+        when(userAlbumRepository.findAllByAlbum(testAlbum)).thenReturn(fullMembers);
+
+        // when & then
+        assertThatThrownBy(() -> albumService.acceptInvite(token))
+                .isInstanceOf(AlbumException.class)
+                .hasMessageContaining("앨범 구성원 정원 초과입니다.");
+    }
+
+
+    @Test
     void acceptInvite_토큰없음_예외() {
         // given
         when(redisInviteTokenRepository.existsByToken(token)).thenReturn(false);

--- a/src/test/java/ongi/ongibe/domain/album/service/AlbumInviteServiceTest.java
+++ b/src/test/java/ongi/ongibe/domain/album/service/AlbumInviteServiceTest.java
@@ -24,6 +24,7 @@ import ongi.ongibe.domain.album.repository.AlbumRepository;
 import ongi.ongibe.domain.album.repository.RedisInviteTokenRepository;
 import ongi.ongibe.domain.album.repository.UserAlbumRepository;
 import ongi.ongibe.domain.auth.OAuthProvider;
+import ongi.ongibe.domain.notification.event.InviteMemberNotificationEvent;
 import ongi.ongibe.domain.user.UserStatus;
 import ongi.ongibe.domain.user.entity.User;
 import ongi.ongibe.domain.user.repository.UserRepository;
@@ -194,6 +195,16 @@ class AlbumInviteServiceTest {
         assertThat(saved.getUser()).isEqualTo(inviteTestUser);
         assertThat(saved.getAlbum()).isEqualTo(testAlbum);
         assertThat(saved.getRole()).isEqualTo(UserAlbumRole.NORMAL);
+        verify(transactionAfterCommitExecutor).execute(any(Runnable.class));
+
+        ArgumentCaptor<InviteMemberNotificationEvent> inviteCaptor =
+                ArgumentCaptor.forClass(InviteMemberNotificationEvent.class);
+
+        verify(applicationEventPublisher).publishEvent(inviteCaptor.capture());
+
+        InviteMemberNotificationEvent publishedEvent = inviteCaptor.getValue();
+        assertThat(publishedEvent.albumId()).isEqualTo(albumId);
+        assertThat(publishedEvent.actorId()).isEqualTo(inviteTestUser.getId());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #521 

## 📝작업 내용

> 기존 invite token 사용 시 토큰을 삭제했는데 삭제 대신 ttl 부여하여 24시간 내 토큰 재사용 가능
<img width="300" alt="스크린샷 2025-06-23 10 56 34" src="https://github.com/user-attachments/assets/89aa8aa5-b08a-4015-85b0-6177556a66c6" />
