### PR TITLE
comment dto에 commentId 추가

### DIFF
--- a/src/main/java/ongi/ongibe/domain/album/dto/AlbumCommentResponseDTO.java
+++ b/src/main/java/ongi/ongibe/domain/album/dto/AlbumCommentResponseDTO.java
@@ -5,6 +5,7 @@ import ongi.ongibe.domain.album.entity.Comments;
 import ongi.ongibe.domain.user.entity.User;
 
 public record AlbumCommentResponseDTO(
+        Long commentId,
         String userName,
         String userProfile,
         String content,
@@ -13,6 +14,7 @@ public record AlbumCommentResponseDTO(
     public static AlbumCommentResponseDTO from(Comments comment) {
         User user = comment.getUser();
         return new AlbumCommentResponseDTO(
+                comment.getId(),
                 user.getNickname(),
                 user.getProfileImage(),
                 comment.getContent(),


### PR DESCRIPTION
기존 : response dto에 id가 없어 수정, 삭제가 불가
개선 : response dto에 id 추가
```
{
  "code" : "COMMENT_READ_SUCCESS"
  "message" : "댓글 조회에 성공했습니다."
  "data" : [
    {
        "commentId" : 123,
        "userName" : "유저 닉네임",
        "userProfile" : "cdn.ongi.today.img_url.jpg"
        "content" : "댓글댓글",
        "createdAt" : "댓글 생성 일시"
    }
    ]
}
```