### PR TITLE
feat: 타임존 명시

### DIFF
--- a/src/main/java/ongi/ongibe/global/config/TimeConfig.java
+++ b/src/main/java/ongi/ongibe/global/config/TimeConfig.java
@@ -1,0 +1,13 @@
+package ongi.ongibe.global.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+    @PostConstruct
+    public void init() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}


### PR DESCRIPTION
서버 올라가니까 UTC 기준으로 db에 저장되는 현상 발생
명시적으로 korean time zone 적용
```
@Configuration
public class TimeConfig {
    @PostConstruct
    public void init() {
        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
    }
}
```